### PR TITLE
Corrección de faltas de ortografía y bloqueo de ventana modal 

### DIFF
--- a/Views/Personas/Index.cshtml
+++ b/Views/Personas/Index.cshtml
@@ -46,7 +46,7 @@
 
 
 <div class="modal fade modalCustom" id="modalCrearPersona" aria-labelledby="modalCrearPersona" aria-hidden="true">
-    <div class="modal-dialog modal-xl boxShadow modal-dialog-centered">
+    <div class="modal-dialog modal-xl boxShadow modal-dialog-centered ">
         <div class="modal-content">
             <div class="row align-items-center justify-content-between px-4 px-md-4 pt-3 pb-2">
                 <div class="col-auto pe-0">
@@ -144,6 +144,7 @@
             dataType: "html",
             success: function (data) {
                 $('#modalBodyCrearPersona').html(data);
+                $('#modalCrearPersona').modal({backdrop: 'static', keyboard: false})
                 $('#modalCrearPersona').modal('show');
             }
         });
@@ -157,6 +158,7 @@
             dataType: "html",
             success: function (value) {
                 $('#modalBodyEditarPersona').html(value);
+                $('#modalEditarPersona').modal({ backdrop: 'static', keyboard: false })
                 $('#modalEditarPersona').modal('show');
             }
         });

--- a/Views/Personas/_CrearPersona.cshtml
+++ b/Views/Personas/_CrearPersona.cshtml
@@ -58,7 +58,7 @@
     <div class="row my-2">
         <div class="col-md-6">
             <div class="controlForm">
-                <label>Genéro:</label>
+                <label>Género:</label>
                 @(Html.Kendo().DropDownListFor(m => m.idGenero)
                     .BindTo((SelectList)ViewBag.CatGeneros)
                     .OptionLabel("-- Seleccione --")
@@ -124,7 +124,7 @@
         <div class="col-md-4">
             <div class="controlForm">
                 @(Html.Kendo().TextBoxFor(t => t.PersonaDireccion.codigoPostal)
-                    .Label(l => l.Content("Codigo postal: <b>(obligatorio)</b>:"))
+                    .Label(l => l.Content("Código postal: <b>(obligatorio)</b>:"))
                     .HtmlAttributes(new { style = "width: 100%; height:58px;", required = "required" })
                     )
             </div>


### PR DESCRIPTION
El bloqueo de ventana modal dando clic fuera de ella es para no perder información por si se cierra la ventana accidentalmente. 